### PR TITLE
Update calls to enet_init() to use fewer args

### DIFF
--- a/t41ether/lwip_dns/lwip_dns.ino
+++ b/t41ether/lwip_dns/lwip_dns.ino
@@ -114,7 +114,7 @@ void setup()
     inet_aton(MASK, &mask);
     inet_aton(GW, &gateway);
   }
-  enet_init(PHY_ADDR, mac, &ip, &mask, &gateway);
+  enet_init(&ip, &mask, &gateway);
   netif_set_status_callback(netif_default, netif_status_callback);
   netif_set_link_callback(netif_default, link_status_callback);
   netif_set_up(netif_default);

--- a/t41ether/lwip_echosrv/lwip_echosrv.ino
+++ b/t41ether/lwip_echosrv/lwip_echosrv.ino
@@ -159,7 +159,7 @@ void setup()
     inet_aton(MASK, &mask);
     inet_aton(GW, &gateway);
   }
-  enet_init(PHY_ADDR, mac, &ip, &mask, &gateway);
+  enet_init(&ip, &mask, &gateway);
   netif_set_status_callback(netif_default, netif_status_callback);
   netif_set_link_callback(netif_default, link_status_callback);
   netif_set_up(netif_default);

--- a/t41ether/lwip_ftpd/lwip_ftpd.ino
+++ b/t41ether/lwip_ftpd/lwip_ftpd.ino
@@ -113,7 +113,7 @@ void setup()
     inet_aton(MASK, &mask);
     inet_aton(GW, &gateway);
   }
-  enet_init(PHY_ADDR, mac, &ip, &mask, &gateway);
+  enet_init(&ip, &mask, &gateway);
   netif_set_status_callback(netif_default, netif_status_callback);
   netif_set_link_callback(netif_default, link_status_callback);
   netif_set_up(netif_default);

--- a/t41ether/lwip_httpd/lwip_httpd.ino
+++ b/t41ether/lwip_httpd/lwip_httpd.ino
@@ -168,7 +168,7 @@ void setup()
     inet_aton(MASK, &mask);
     inet_aton(GW, &gateway);
   }
-  enet_init(PHY_ADDR, mac, &ip, &mask, &gateway);
+  enet_init(&ip, &mask, &gateway);
   netif_set_status_callback(netif_default, netif_status_callback);
   netif_set_link_callback(netif_default, link_status_callback);
   netif_set_up(netif_default);

--- a/t41ether/lwip_httpd_sdfat/lwip_httpd_sdfat.ino
+++ b/t41ether/lwip_httpd_sdfat/lwip_httpd_sdfat.ino
@@ -168,7 +168,7 @@ void setup()
     inet_aton(MASK, &mask);
     inet_aton(GW, &gateway);
   }
-  enet_init(PHY_ADDR, mac, &ip, &mask, &gateway);
+  enet_init(&ip, &mask, &gateway);
   netif_set_status_callback(netif_default, netif_status_callback);
   netif_set_link_callback(netif_default, link_status_callback);
   netif_set_up(netif_default);

--- a/t41ether/lwip_iperf/lwip_iperf.ino
+++ b/t41ether/lwip_iperf/lwip_iperf.ino
@@ -79,7 +79,7 @@ void setup()
         inet_aton(MASK, &mask);
         inet_aton(GW, &gateway);
     }
-    enet_init(PHY_ADDR, mac, &ip, &mask, &gateway);
+    enet_init(&ip, &mask, &gateway);
     netif_set_status_callback(netif_default, netif_status_callback);
     netif_set_link_callback(netif_default, link_status_callback);
     netif_set_up(netif_default);

--- a/t41ether/lwip_mcast/lwip_mcast.ino
+++ b/t41ether/lwip_mcast/lwip_mcast.ino
@@ -168,7 +168,7 @@ void setup()
     inet_aton(MASK, &mask);
     inet_aton(GW, &gateway);
   }
-  enet_init(PHY_ADDR, mac, &ip, &mask, &gateway);
+  enet_init(&ip, &mask, &gateway);
   netif_set_status_callback(netif_default, netif_status_callback);
   netif_set_link_callback(netif_default, link_status_callback);
   netif_set_up(netif_default);

--- a/t41ether/lwip_perf/lwip_perf.ino
+++ b/t41ether/lwip_perf/lwip_perf.ino
@@ -420,7 +420,7 @@ void setup()
     inet_aton(MASK, &mask);
     inet_aton(GW, &gateway);
   }
-  enet_init(PHY_ADDR, mac, &ip, &mask, &gateway);
+  enet_init(&ip, &mask, &gateway);
   netif_set_status_callback(netif_default, netif_status_callback);
   netif_set_link_callback(netif_default, link_status_callback);
   netif_set_up(netif_default);

--- a/t41ether/lwip_sntp/lwip_sntp.ino
+++ b/t41ether/lwip_sntp/lwip_sntp.ino
@@ -242,7 +242,7 @@ void setup()
         inet_aton(MASK, &mask);
         inet_aton(GW, &gateway);
     }
-    enet_init(PHY_ADDR, mac, &ip, &mask, &gateway);
+    enet_init(&ip, &mask, &gateway);
     netif_set_status_callback(netif_default, netif_status_callback);
     netif_set_link_callback(netif_default, link_status_callback);
     netif_set_up(netif_default);

--- a/t41ether/lwip_tftpd/lwip_tftpd.ino
+++ b/t41ether/lwip_tftpd/lwip_tftpd.ino
@@ -171,7 +171,7 @@ void setup()
     inet_aton(MASK, &mask);
     inet_aton(GW, &gateway);
   }
-  enet_init(PHY_ADDR, mac, &ip, &mask, &gateway);
+  enet_init(&ip, &mask, &gateway);
   netif_set_status_callback(netif_default, netif_status_callback);
   netif_set_link_callback(netif_default, link_status_callback);
   netif_set_up(netif_default);

--- a/t41ether/lwip_tftpd_SPIFFS/lwip_tftpd_SPIFFS.ino
+++ b/t41ether/lwip_tftpd_SPIFFS/lwip_tftpd_SPIFFS.ino
@@ -157,7 +157,7 @@ void setup()
     inet_aton(MASK, &mask);
     inet_aton(GW, &gateway);
   }
-  enet_init(PHY_ADDR, mac, &ip, &mask, &gateway);
+  enet_init(&ip, &mask, &gateway);
   netif_set_status_callback(netif_default, netif_status_callback);
   netif_set_link_callback(netif_default, link_status_callback);
   netif_set_up(netif_default);

--- a/t41ether/lwip_tftpd_sdfat/lwip_tftpd_sdfat.ino
+++ b/t41ether/lwip_tftpd_sdfat/lwip_tftpd_sdfat.ino
@@ -170,7 +170,7 @@ void setup()
     inet_aton(MASK, &mask);
     inet_aton(GW, &gateway);
   }
-  enet_init(PHY_ADDR, mac, &ip, &mask, &gateway);
+  enet_init(&ip, &mask, &gateway);
   netif_set_status_callback(netif_default, netif_status_callback);
   netif_set_link_callback(netif_default, link_status_callback);
   netif_set_up(netif_default);

--- a/t41ether/lwip_webclnt/lwip_webclnt.ino
+++ b/t41ether/lwip_webclnt/lwip_webclnt.ino
@@ -176,7 +176,7 @@ void setup()
     inet_aton(MASK, &mask);
     inet_aton(GW, &gateway);
   }
-  enet_init(PHY_ADDR, mac, &ip, &mask, &gateway);
+  enet_init(&ip, &mask, &gateway);
   netif_set_status_callback(netif_default, netif_status_callback);
   netif_set_link_callback(netif_default, link_status_callback);
   netif_set_up(netif_default);

--- a/t41ether/lwip_websrv/lwip_websrv.ino
+++ b/t41ether/lwip_websrv/lwip_websrv.ino
@@ -180,7 +180,7 @@ void setup()
     inet_aton(MASK, &mask);
     inet_aton(GW, &gateway);
   }
-  enet_init(PHY_ADDR, mac, &ip, &mask, &gateway);
+  enet_init(&ip, &mask, &gateway);
   netif_set_status_callback(netif_default, netif_status_callback);
   netif_set_link_callback(netif_default, link_status_callback);
   netif_set_up(netif_default);


### PR DESCRIPTION
Update the lwip_* example programs to use the updated enet_init() from commit e381dc30e61ad887f61ff01d11aac459c6fd539e.